### PR TITLE
Utiliser la couleur Tchap pour le fond du bouton "Envoyer un message

### DIFF
--- a/Sources/Compound/Buttons/SendButton.swift
+++ b/Sources/Compound/Buttons/SendButton.swift
@@ -48,7 +48,9 @@ public struct SendButton: View {
     
     var buttonShape: some View {
         Circle()
-            .fill(LinearGradient(gradient: gradient, startPoint: .top, endPoint: .bottom))
+        // Tchap: use Tchap main background action color.
+//            .fill(LinearGradient(gradient: gradient, startPoint: .top, endPoint: .bottom))
+            .fill(.compound.bgActionPrimaryRest)
     }
 }
 


### PR DESCRIPTION
Fix #1 

![Image](https://github.com/user-attachments/assets/185388bb-9140-43d1-a164-653209a68d98)

![Image](https://github.com/user-attachments/assets/269474cc-8335-4df8-a055-d7dce631bdc0)